### PR TITLE
remove unnecessary closing of a file

### DIFF
--- a/mqtt2spacestatus.py
+++ b/mqtt2spacestatus.py
@@ -20,7 +20,6 @@ def read_configuration(path="config.yaml"):
     """
     with open(path, "r") as conffile:
         conf = yaml.load(conffile)
-        conffile.close()
 
     return conf
 


### PR DESCRIPTION
 'with open("file.foo") as file:' closes the file for you